### PR TITLE
Single entity fetch and additional methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "teodortalov/citrix",
-    "description": "PHP wrapper around Citrix - GoToMeeting and GoToWebinar APIs",
+    "name": "oytuntez/citrix",
+    "description": "PHP wrapper around Citrix - GoToMeeting and GoToWebinar APIs. Forked from teodortalov/citrix.",
     "keywords": ["Citrix", "Citrix API", "GoToWebinar API", "GoToMeeting API", "GoToWebinar"],
     "license": "MIT",
     "authors": [

--- a/src/Citrix/GoToWebinar.php
+++ b/src/Citrix/GoToWebinar.php
@@ -112,6 +112,22 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
 
     return $this->getResponse();
   }
+  /**
+   * Get all attendees for a given webinar.
+   *
+   * @param int $webinarKey
+   * @return \Citrix\Entity\Consumer
+   */
+  public function getAttendees($webinarKey){
+
+    $url = 'https://api.citrixonline.com/G2W/rest/organizers/' . $this->getClient()->getOrganizerKey() . '/webinars/' . $webinarKey . '/attendees';
+    $this->setHttpMethod('GET')
+        ->setUrl($url)
+        ->sendRequest($this->getClient()->getAccessToken())
+        ->processResponse();
+
+    return $this->getResponse();
+  }
   
   /**
    * Register user for a webinar


### PR DESCRIPTION
Hello!

Thank you so much for bringing this package together. I started using it, however it was missing a couple methods that I needed and had a glitch with single entity responses.

- processResponse() method wasn't able to process single entity responses such as single webinar or single registrant or single attendee requests. (some of these methods didn't exist anyway, so only getWebinar() method wasn't working). Now there is an optional parameter on processResponse: if you want it to process a single entity response from server, you need to pass "true" as the first parameter.

- I added a couple of other methods: 
  - getWebinars: list all webinars, upcoming or past.
  - getRegistrant: get a single registrant with webinar and registrant key.
  - getAttendees: get a list of attendees of all sessions of a webinar.

I think that's it... I will continue sending PRs as I find other stuff during my subproject.