### PR TITLE
New method: get past webinars.

### DIFF
--- a/src/Citrix/Entity/Webinar.php
+++ b/src/Citrix/Entity/Webinar.php
@@ -95,7 +95,7 @@ class Webinar extends EntityAbstract implements EntityAware
     $this->organizerKey = $data['organizerKey'];
     $this->times = $data['times'];
     $this->timeZone = $data['timeZone'];
-    $this->registrationUrl = $data['registrationUrl'];
+    $this->registrationUrl = isset($data['registrationUrl']) ? $data['registrationUrl'] : null;
     return $this;
   }
 

--- a/src/Citrix/GoToWebinar.php
+++ b/src/Citrix/GoToWebinar.php
@@ -63,6 +63,25 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
   }
 
   /**
+   * Get all webinars.
+   *
+   * @return \ArrayObject - Processed response
+   */
+  public function getPastWebinars(){
+    $since = date(DATE_ISO8601, mktime(0, 0, 0, 7, 1, 2000));
+    $until = date(DATE_ISO8601);
+    $url = 'https://api.citrixonline.com/G2W/rest/organizers/' . $this->getClient()->getOrganizerKey() . '/historicalWebinars';
+
+    $this->setHttpMethod('GET')
+        ->setParams(['fromTime' => $since, 'toTime' => $until])
+         ->setUrl($url)
+         ->sendRequest($this->getClient()->getAccessToken())
+         ->processResponse();
+
+    return $this->getResponse();
+  }
+
+  /**
    * Get info for a single webinar by passing the webinar id or 
    * in Citrix's terms webinarKey.
    * 


### PR DESCRIPTION
Get past webinars. 

/webinars or /upcomingWebinars always bring only upcoming webinars, somehow. I put this new method calling /historicalWebinars to fetch past webinars. Past webinars do not have "registrationUrl", hence that property is now optional.