### PR TITLE
Added getRegistrantsFields and modified processResponse

### DIFF
--- a/src/Citrix/GoToWebinar.php
+++ b/src/Citrix/GoToWebinar.php
@@ -190,7 +190,7 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
     $this->setHttpMethod('POST')
         ->setUrl($url)
         ->setParams($registrantData)
-        ->sendRequest($this->getClient()->getAccessToken())
+        ->sendRequest($this->getClient()->getAccessToken(), array('accept' => 'application/vnd.citrix.g2wapi-v1.1+json' ))
         ->processResponse();
 
     return $this;
@@ -233,43 +233,8 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
       $this->addError($response['description']);
     }
 
-    if($single === true) {
-      if(isset($response['webinarKey'])){
-        $webinar = new Webinar($this->getClient());
-        $webinar->setData($response)->populate();
-        $this->setResponse($webinar);
-      }
 
-      if(isset($response['registrantKey'])){
-        $webinar = new Consumer($this->getClient());
-        $webinar->setData($response)->populate();
-        $this->setResponse($webinar);
-      }
-    } else {
-      $collection = new \ArrayObject(array());
-
-
-      foreach ($response as $entity){
-        if(isset($entity['webinarKey'])){
-          $webinar = new Webinar($this->getClient());
-          $webinar->setData($entity)->populate();
-          $collection->append($webinar);
-        }
-
-        if(isset($entity['registrantKey'])){
-          $webinar = new Consumer($this->getClient());
-          $webinar->setData($entity)->populate();
-          $collection->append($webinar);
-        }
-
-        if( !isset($entity['registrantKey'] ) && !isset($entity['webinarKey']) ) {
-            $collection->exchangeArray( $response );
-        }
-
-      }
-
-      $this->setResponse($collection);
-    }
+    return $response;
   }
 }
 

--- a/src/Citrix/GoToWebinar.php
+++ b/src/Citrix/GoToWebinar.php
@@ -125,6 +125,25 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
     return $this->getResponse();
   }
 
+
+  /**
+   * Get registrations fields
+   * 
+   * @param int $webinarKey
+   * @return \Citrix\Entity\Consumer
+   */
+  public function getRegistrantsFields($webinarKey){
+    
+    $url = 'https://api.citrixonline.com/G2W/rest/organizers/' . $this->getClient()->getOrganizerKey() . '/webinars/' . $webinarKey . '/registrants/fields';
+    $this->setHttpMethod('GET')
+         ->setUrl($url)
+         ->sendRequest($this->getClient()->getAccessToken())
+         ->processResponse();
+    
+    return $this->getResponse();
+  }
+
+
   /**
    * Get a single registrant for a given webinar.
    *

--- a/src/Citrix/GoToWebinar.php
+++ b/src/Citrix/GoToWebinar.php
@@ -7,7 +7,7 @@ use Citrix\Entity\Consumer;
 
 /**
  * Use this to get/post data from/to Citrix.
- * 
+ *
  * @uses \Citrix\ServiceAbstract
  * @uses \Citrix\CitrixApiAware
  */
@@ -16,14 +16,14 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
 
   /**
    * Authentication Client
-   * 
+   *
    * @var Citrix
    */
   private $client;
 
   /**
    * Begin here by passing an authentication class.
-   * 
+   *
    * @param $client - authentication client
    */
   public function __construct($client)
@@ -33,17 +33,17 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
 
   /**
    * Get upcoming webinars.
-   * 
+   *
    * @return \ArrayObject - Processed response
    */
   public function getUpcoming(){
-    
+
     $url = 'https://api.citrixonline.com/G2W/rest/organizers/' . $this->getClient()->getOrganizerKey() . '/upcomingWebinars';
     $this->setHttpMethod('GET')
          ->setUrl($url)
          ->sendRequest($this->getClient()->getAccessToken())
          ->processResponse();
-    
+
     return $this->getResponse();
   }
 
@@ -93,9 +93,9 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
   }
 
   /**
-   * Get info for a single webinar by passing the webinar id or 
+   * Get info for a single webinar by passing the webinar id or
    * in Citrix's terms webinarKey.
-   * 
+   *
    * @param int $webinarKey
    * @return \Citrix\Entity\Webinar
    */
@@ -110,36 +110,35 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
   }
   /**
    * Get all registrants for a given webinar.
-   * 
+   *
    * @param int $webinarKey
    * @return \Citrix\Entity\Consumer
    */
   public function getRegistrants($webinarKey){
-    
+
     $url = 'https://api.citrixonline.com/G2W/rest/organizers/' . $this->getClient()->getOrganizerKey() . '/webinars/' . $webinarKey . '/registrants';
     $this->setHttpMethod('GET')
          ->setUrl($url)
          ->sendRequest($this->getClient()->getAccessToken())
          ->processResponse();
-    
+
     return $this->getResponse();
   }
 
 
   /**
    * Get registrations fields
-   * 
+   *
    * @param int $webinarKey
    * @return \Citrix\Entity\Consumer
    */
   public function getRegistrantsFields($webinarKey){
-    
     $url = 'https://api.citrixonline.com/G2W/rest/organizers/' . $this->getClient()->getOrganizerKey() . '/webinars/' . $webinarKey . '/registrants/fields';
     $this->setHttpMethod('GET')
          ->setUrl($url)
          ->sendRequest($this->getClient()->getAccessToken())
          ->processResponse();
-    
+
     return $this->getResponse();
   }
 
@@ -177,10 +176,10 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
 
     return $this->getResponse();
   }
-  
+
   /**
    * Register user for a webinar
-   * 
+   *
    * @param int $webinarKey
    * @param array $registrantData - email, firstName, lastName (required)
    * @return \Citrix\GoToWebinar
@@ -207,12 +206,12 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
 
   /**
    *
-   * @param Citrix $client          
+   * @param Citrix $client
    */
   private function setClient($client)
   {
     $this->client = $client;
-    
+
     return $this;
   }
   /* (non-PHPdoc)
@@ -229,7 +228,7 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
     if(isset($response['int_err_code'])){
       $this->addError($response['msg']);
     }
-    
+
     if(isset($response['description'])){
       $this->addError($response['description']);
     }
@@ -249,6 +248,7 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
     } else {
       $collection = new \ArrayObject(array());
 
+
       foreach ($response as $entity){
         if(isset($entity['webinarKey'])){
           $webinar = new Webinar($this->getClient());
@@ -261,6 +261,11 @@ class GoToWebinar extends ServiceAbstract implements CitrixApiAware
           $webinar->setData($entity)->populate();
           $collection->append($webinar);
         }
+
+        if( !isset($entity['registrantKey'] ) && !isset($entity['webinarKey']) ) {
+            $collection->exchangeArray( $response );
+        }
+
       }
 
       $this->setResponse($collection);

--- a/src/Citrix/ServiceAbstract.php
+++ b/src/Citrix/ServiceAbstract.php
@@ -14,7 +14,7 @@ abstract class ServiceAbstract
 
   /**
    * List of errors that have occured
-   * 
+   *
    * @var Array
    */
   private $errors = array();
@@ -29,38 +29,44 @@ abstract class ServiceAbstract
 
   /**
    * URL to be called
-   * 
+   *
    * @var String
    */
   private $url;
 
   /**
    * Response from Citrix API call
-   * 
+   *
    * @var Array
    */
   private $response;
 
   /**
    * HTTP METHOD used - POST | GET
-   * 
+   *
    * @var String
    */
   private $httpMethod = 'POST';
 
   /**
    * Send API request, but pass the $oauthToken first.
-   * 
+   *
    * @see \Citrix\Citrix
    *
-   * @param string $oauthToken          
+   * @param string $oauthToken
    * @return \Citrix\ServiceAbstract
    */
-  public function sendRequest($oauthToken = null)
+  public function sendRequest($oauthToken = null, $args = array() )
   {
+      $defaults = array(
+          'accept' => 'application/json',
+      );
+
+      $args = array_merge( $defaults, $args );
+
     $url = $this->getUrl();
     $ch = curl_init(); // initiate curl
-    
+
     if ($this->getHttpMethod() == 'POST') {
       curl_setopt($ch, CURLOPT_POST, true); // tell curl you want to post something
       curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($this->getParams())); // define what you want to post
@@ -69,16 +75,16 @@ abstract class ServiceAbstract
       $query = http_build_query($this->getParams());
       $url = $url . '?' . $query;
     }
-    
+
     if (! is_null($oauthToken)) {
       $headers = array(
         'Content-Type: application/json',
-        'Accept: application/json',
+        'Accept: ' . $args['accept'],
         'Authorization: OAuth oauth_token=' . $oauthToken
       );
       curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
     }
-    
+
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true); // return the output in string format
     $output = curl_exec($ch); // execute
@@ -112,7 +118,7 @@ abstract class ServiceAbstract
 
   /**
    * Get all errors
-   * 
+   *
    * @return Array
    */
   public function getErrors()
@@ -125,13 +131,13 @@ abstract class ServiceAbstract
   /**
    * Add a new error
    *
-   * @param String $message          
+   * @param String $message
    * @return \Citrix\ServiceAbstract
    */
   public function addError($message)
   {
     $this->errors[] = $message;
-    
+
     return $this;
   }
 
@@ -143,7 +149,7 @@ abstract class ServiceAbstract
   public function reset()
   {
     $this->errors = array();
-    
+
     return $this;
   }
 
@@ -158,26 +164,26 @@ abstract class ServiceAbstract
 
   /**
    *
-   * @param Array $params          
+   * @param Array $params
    */
   public function setParams($params)
   {
     $this->params = $params;
-    
+
     return $this;
   }
 
   /**
    * Add a new param to be passed to API
    *
-   * @param String $key          
-   * @param String $value          
+   * @param String $key
+   * @param String $value
    * @return \Citrix\ServiceAbstract
    */
   public function addParam($key, $value)
   {
     $this->params[$key] = $value;
-    
+
     return $this;
   }
 
@@ -192,12 +198,12 @@ abstract class ServiceAbstract
 
   /**
    *
-   * @param String $url          
+   * @param String $url
    */
   public function setUrl($url)
   {
     $this->url = $url;
-    
+
     return $this;
   }
 
@@ -225,7 +231,7 @@ abstract class ServiceAbstract
 
     $this->response = (array) json_decode($response, true, 512, JSON_BIGINT_AS_STRING);
     return $this;
-    
+
   }
 
   /**
@@ -239,7 +245,7 @@ abstract class ServiceAbstract
 
   /**
    * Set the HttpMethod
-   * 
+   *
    * @param String $httpMethod
    *          - GET | POST
    * @return \Citrix\ServiceAbstract
@@ -247,7 +253,7 @@ abstract class ServiceAbstract
   public function setHttpMethod($httpMethod)
   {
     $this->httpMethod = $httpMethod;
-    
+
     return $this;
   }
 }


### PR DESCRIPTION
Hi there Teodor, 

I've just begun using your awesome class and I would like to make some more changes so I would like to use this pull request as a way to discuss some things, if that's ok with you :) 

My biggest concern is the processResponse function, here's why. I created the getRegistrantsFields which retrieves the fields used for registration. Since $singe is false a new ArrayObject is created. The code then iterates through each item in the response and adds it to the arrayObject if the 'registrantKey' or 'webinarKey' index is set. 

The getRegistrantsFields call returns a totally different structure so I ended up with no results at all. I fixed this temporarily like this, but I don't think this is a great solution: 

`if( !isset($entity['registrantKey'] ) && !isset($entity['webinarKey']) ) {
    $collection->exchangeArray( $response );
}`

I was wondering, why use ArrayObject at all? The setResponse function in ServiceAbstrsct makes sure an object or an array is returned so using ArrayObject seems unnecessary. It would also remove the need to use the $single parameter in the process. I have two other issues with the $single parameter:
- The interface does not define this
- I don't think it should be the processResponse's job to figure out if the response is for a single entity or not

Let me know what you think, I'll be using the API somewhat in the next couple of days, perhaps we can make the class a bit better together :) Thanks for your awesome work so far!

Daniel
